### PR TITLE
Set X-PM-Message-Id into swift message headers

### DIFF
--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -59,7 +59,12 @@ class PostmarkTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $this->client->post($this->url, $this->payload($message));
+        $response = $this->client->post($this->url, $this->payload($message));
+
+        $message->getHeaders()->addTextHeader(
+            'X-PM-Message-Id',
+            $this->getMessageId($response)
+        );
 
         $this->sendPerformed($message);
 
@@ -126,6 +131,20 @@ class PostmarkTransport extends Transport
             })
             ->values()
             ->implode(',');
+    }
+
+    /**
+     * Get the message ID from the response.
+     *
+     * @param \GuzzleHttp\Psr7\Response $response
+     * @return string
+     */
+    protected function getMessageId($response)
+    {
+        return object_get(
+            json_decode($response->getBody()->getContents()),
+            'MessageID'
+        );
     }
 
     /**

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -96,6 +96,7 @@ class PostmarkTransportTest extends TestCase
     {
         try {
             $this->transport->send($this->message);
+            $this->assertNotNull($this->message->getHeaders()->get('X-PM-Message-Id'));
         } catch (RequestException $e) {
             $this->fail($e->getMessage());
         }


### PR DESCRIPTION
This PR gets the response from the Postmark API and sets the swift message header X-PM-Message-Id to the returned MessageID.