### PR TITLE
getAttachments should return array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- getAttachments method should return array instead of Collection.
+
 ## [2.1.2] - 2017-10-06
 
 ### Updated

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -68,7 +68,7 @@ class PostmarkTransport extends Transport
      *
      * @param \Swift_Mime_SimpleMessage $message
      *
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
     protected function getAttachments(Swift_Mime_SimpleMessage $message)
     {
@@ -82,7 +82,8 @@ class PostmarkTransport extends Transport
                     'Content' => base64_encode($child->getBody()),
                     'ContentType' => $child->getContentType(),
                 ];
-            });
+            })
+            ->toArray();
     }
 
     /**

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -45,7 +45,7 @@ class PostmarkTransportTest extends TestCase
     }
 
     /** @test */
-    public function can_given_contacts_into_a_comma_separated_string()
+    public function can_get_given_contacts_into_a_comma_separated_string()
     {
         $to = $this->invokeMethod($this->transport, 'getContacts', [$this->message->getTo()]);
         $cc = $this->invokeMethod($this->transport, 'getContacts', [$this->message->getCc()]);
@@ -56,6 +56,20 @@ class PostmarkTransportTest extends TestCase
         $this->assertEquals('cc@example.com', $cc);
         $this->assertEquals('bcc@example.com', $bcc);
         $this->assertEquals('replyTo@example.com', $replyTo);
+    }
+
+    /** @test */
+    public function can_get_given_attachments_into_array()
+    {
+        $attachments = $this->invokeMethod($this->transport, 'getAttachments', [$this->message]);
+
+        $this->assertEquals([
+            [
+                'Name' => 'test.txt',
+                'Content' => 'dGVzdCBhdHRhY2htZW50',
+                'ContentType' => 'text/plain',
+            ]
+        ], $attachments);
     }
 
     /** @test */


### PR DESCRIPTION
The getAttachments function should return an array instead of a collection. 
Added a test for this as well.