### PR TITLE
Fix: comma in display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Display names containing a comma results in API error 300.
+
+### Added
 - Added suggestion of mvdnbrk/postmark-inbound to composer.json.
 
 ## [2.1.4] - 2017-10-08

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -88,6 +88,21 @@ class PostmarkTransport extends Transport
     }
 
     /**
+     * Format the display name.
+     *
+     * @param  string
+     * @return string
+     */
+    protected function getDisplayname($value)
+    {
+        if (strpos($value, ',') !== false) {
+            return '"' . $value . '"';
+        }
+
+        return $value;
+    }
+
+    /**
      * Format the contacts for the API request.
      *
      * @param string|array $contacts
@@ -98,7 +113,7 @@ class PostmarkTransport extends Transport
     {
         return collect($contacts)
             ->map(function ($display, $address) {
-                return $display ? $display . " <{$address}>" : $address;
+                return $display ? $this->getDisplayname($display) . " <{$address}>" : $address;
             })
             ->values()
             ->implode(',');

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -388,6 +388,17 @@ class PostmarkTransportTest extends TestCase
     }
 
     /** @test */
+    public function display_name_with_a_comma_should_be_double_quoted_the_payload()
+    {
+        $this->message->setTo('john@example.com', 'Doe, John');
+        $payload = $this->getPayload($this->message);
+
+        tap($payload['json'], function ($json) {
+            $this->assertSame('"Doe, John" <john@example.com>', $json['To']);
+        });
+    }
+
+    /** @test */
     public function can_send_an_email_through_postmarks_api()
     {
         try {


### PR DESCRIPTION
A display name containing a comma results in an API error.

`{From: 'sender@domain.com', To: 'Doe, John <john@example.com>', Subject: 'test'}`

Postmark API response:
`{"ErrorCode":300,"Message":"Error parsing 'To': Illegal email address 'Doe'. It must contain the '@' symbol."}`

This PR fixes that.