### PR TITLE
Updates phpunit.xml.dist file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixes phpunit.xml.dist file. [`fd75059cd1`](https://github.com/coconutcraig/laravel-postmark/commit/fd75059cd1)
+
 ## [2.2.0] - 2018-02-19
 
 - Updates travis configuration [`ae914ea34a`](https://github.com/coconutcraig/laravel-postmark/commit/ae914ea34a) 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,7 @@
     </filter>
     <logging>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>


### PR DESCRIPTION
Since PHPUnit version 7.2 the XML is validated against the schema. [see #3055](https://github.com/sebastianbergmann/phpunit/pull/3066).

Running the tests as of PHPUnit 7.2 produces the following warning:

```
Warning - The configuration file did not pass validation!
The following problems have been detected:

Line 24:
- Element 'log', attribute 'charset': The attribute 'charset' is not allowed.
- Element 'log', attribute 'yui': The attribute 'yui' is not allowed.
- Element 'log', attribute 'highlight': The attribute 'highlight' is not allowed.

Test results may not be as expected.
```

This PR fixes this issue with an updated phpunit.xml.dist file.