### PR TITLE
Adds phpunit.xml to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
+phpunit.xml
 vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Adds phpunit.xml to .gitignore. [`cb798836a7`](https://github.com/coconutcraig/laravel-postmark/commit/acb798836a7)
+
 ## [2.2.0] - 2018-02-19
 
 - Updates travis configuration [`ae914ea34a`](https://github.com/coconutcraig/laravel-postmark/commit/ae914ea34a) 


### PR DESCRIPTION
Added `phpunit.xml` to `.gitignore`

This allows to have local `phpunit.xml` file without the `<logging>` tag.

The tests will be significantly faster without logging.