### PR TITLE
Adds a postmark config file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Adds a postmark config file. [`e13970dd2d`](https://github.com/coconutcraig/laravel-postmark/commit/e13970dd2d) 
+
 ## [2.2.0] - 2018-02-19
 
 - Updates travis configuration [`ae914ea34a`](https://github.com/coconutcraig/laravel-postmark/commit/ae914ea34a) 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@
 
 > [Postmark](https://postmarkapp.com) is the easiest and most reliable way to be sure your important transactional emails get to your customer's inbox.
 
-## Install
-
-Via Composer
-
-``` bash
-$ composer require coconutcraig/laravel-postmark
-```
-
 ## Support
 
 | Laravel | Laravel Postmark |
@@ -28,6 +20,22 @@ $ composer require coconutcraig/laravel-postmark
 ## Upgrading
 
 Please see [UPGRADE](UPGRADE.md) for details.
+
+## Installation
+
+You can install the package via composer:
+
+``` bash
+$ composer require coconutcraig/laravel-postmark
+```
+
+The package will automatically register itself.
+
+You can optionally publish the config file with:
+
+```bash
+php artisan vendor:publish --provider="Coconuts\Mail\PostmarkServiceProvider" --tag="config"
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,25 +31,10 @@ Please see [UPGRADE](UPGRADE.md) for details.
 
 ## Usage
 
-Update the `config/services.php` file to hold our Postmark specific config.
-
-```php
-return [
-    // ...
-    
-    'postmark' => [
-        'secret' => env('POSTMARK_SECRET'),    
-    ],
-];
-```
-
-Then we can add the server key to our `.env` file and update our `MAIL_DRIVER`.
+Update your `.env` file by adding your server key and set your mail driver to `postmark`.
 
 ```php
 MAIL_DRIVER=postmark
-
-// ...
-
 POSTMARK_SECRET=YOUR-SERVER-KEY-HERE
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,31 @@
 # Upgrade Guide
 
+## From v2.2 to v2.3
+
+You may remove the `postmark` specific key from  the `config/services.php` file.
+We will get your `POSTMARK_SECRET` directly from your `env` file.
+
+```php
+return [
+
+    // You can remove this:    
+    'postmark' => [
+        'secret' => env('POSTMARK_SECRET'),    
+    ],
+
+];
+```
+
+You can optionally publish the config file with:
+
+```bash
+php artisan vendor:publish --provider="Coconuts\Mail\PostmarkServiceProvider" --tag="config"
+```
+
+## From v2.0 to v2.1
+
+When upgrading from v2.0 to v2.1, you can remove the service provider from the providers array in `config/app.php`. This is possible because laravel-postmark v2.1 takes advantage of [Package Auto Discovery](https://laravel-news.com/package-auto-discovery).
+
 ## From v1 to v2.0
 
 When upgrading from v1 to v2.0, you will need to change the old service provider back to the MailServiceProvider that comes with Laravel in `config/app.php`.
@@ -19,7 +45,3 @@ After that, you can add the new service provider to the providers array in `conf
 ```php
 Coconuts\Mail\PostmarkServiceProvider::class,
 ```
-
-## From v2.0 to v2.1
-
-When upgrading from v2.0 to v2.1, you can remove the service provider from the providers array in `config/app.php`. This is possible because laravel-postmark v2.1 takes advantage of [Package Auto Discovery](https://laravel-news.com/package-auto-discovery).

--- a/config/postmark.php
+++ b/config/postmark.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Postmark credentials
+    |--------------------------------------------------------------------------
+    |
+    | Here you may provide your Postmark server API token.
+    |
+    */
+
+    'secret' => env('POSTMARK_SECRET'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Guzzle options
+    |--------------------------------------------------------------------------
+    |
+    | Under the hood we use Guzzle to make API calls to Postmark.
+    | Here you may provide any request options for Guzzle.
+    |
+    */
+
+    'guzzle' => [
+        'timeout' => 10,
+        'connect_timeout' => 10,
+    ],
+];

--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -8,18 +8,22 @@ use Illuminate\Support\ServiceProvider;
 class PostmarkServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap any application services.
+     * Boot the service provider.
      *
      * @return void
      */
     public function boot()
     {
-        $config = $this->app['config']->get('services.postmark', []);
+        $this->publishes([
+            __DIR__ . '/../config/postmark.php' => config_path('postmark.php')
+        ], 'config');
 
-        $this->app['swift.transport']->extend('postmark', function () use ($config) {
+        $this->mergeConfigFrom(__DIR__ . '/../config/postmark.php', 'postmark');
+
+        $this->app['swift.transport']->extend('postmark', function () {
             return new PostmarkTransport(
-                $this->guzzle($config),
-                $config['secret']
+                $this->guzzle(config('postmark.guzzle', [])),
+                config('postmark.secret')
             );
         });
     }
@@ -33,10 +37,6 @@ class PostmarkServiceProvider extends ServiceProvider
      */
     protected function guzzle($config)
     {
-        return new HttpClient(array_add(
-            array_get($config, 'guzzle', []),
-            'connect_timeout',
-            60
-        ));
+        return new HttpClient($config);
     }
 }

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -42,10 +42,7 @@ class PostmarkTransportTest extends TestCase
             $message->addPart('<html>', 'text/html');
         });
 
-        $this->transport = new PostmarkTransport(
-            new Client(),
-            $this->app['config']->get('services.postmark.secret')
-        );
+        $this->transport = $this->app['swift.transport']->driver('postmark');
     }
 
     /**
@@ -64,6 +61,7 @@ class PostmarkTransportTest extends TestCase
     public function can_get_given_contacts_into_a_comma_separated_string()
     {
         $to = $this->invokeMethod($this->transport, 'getContacts', [['me@example.com' => '']]);
+
         $this->assertEquals('me@example.com', $to);
 
         $multiple = $this->invokeMethod($this->transport, 'getContacts', [[
@@ -71,6 +69,7 @@ class PostmarkTransportTest extends TestCase
             'jane@example.com' => 'Jane',
             'user@example.com' => 'User',
         ]]);
+
         $this->assertEquals('John <john@example.com>,Jane <jane@example.com>,User <user@example.com>', $multiple);
     }
 
@@ -94,6 +93,7 @@ class PostmarkTransportTest extends TestCase
     public function can_get_a_mime_part_from_message()
     {
         $this->message->addPart('<html>', 'text/html');
+
         $part = $this->invokeMethod($this->transport, 'getMimePart', [$this->message, 'text/html']);
 
         $this->assertSame('<html>', $part->getBody());
@@ -136,6 +136,7 @@ class PostmarkTransportTest extends TestCase
     {
         $this->message->getHeaders()->addTextHeader('Tag', 'TestTag1');
         $this->message->getHeaders()->addTextHeader('Tag', 'TestTag2');
+
         $tag = $this->invokeMethod($this->transport, 'getTag', [$this->message]);
 
         $this->assertSame('TestTag2', $tag);
@@ -204,6 +205,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_from_address()
     {
         $this->message->setFrom('john@example.com', 'John Doe');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -215,6 +217,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_to_address()
     {
         $this->message->setTo('jane@example.com', 'Jane Doe');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -226,6 +229,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_cc_address()
     {
         $this->message->setCc('foo@example.com', 'Foo');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -237,6 +241,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_bcc_address()
     {
         $this->message->setBcc('bar@example.com', 'Bar');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -248,6 +253,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_subject()
     {
         $this->message->setSubject('Lorem ipsum.');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -259,6 +265,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_tag()
     {
         $this->message->getHeaders()->addTextHeader('Tag', 'TestTag');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -270,6 +277,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_html_body()
     {
         $this->message->setBody('<html>', 'text/html');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -283,6 +291,7 @@ class PostmarkTransportTest extends TestCase
     {
         $message = new \Swift_Message;
         $message->setBody('Lorem ipsum.', 'text/plain');
+
         $payload = $this->getPayload($message);
 
         tap($payload['json'], function ($json) {
@@ -296,6 +305,7 @@ class PostmarkTransportTest extends TestCase
     {
         $this->message->setBody('Lorem ipsum.', 'text/plain');
         $this->message->addPart('<html>', 'text/html');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -310,6 +320,7 @@ class PostmarkTransportTest extends TestCase
         $message = new \Swift_Message;
         $message->setBody('<html>', 'text/html');
         $message->addPart('Lorem ipsum.', 'text/plain');
+
         $payload = $this->getPayload($message);
 
         tap($payload['json'], function ($json) {
@@ -322,6 +333,7 @@ class PostmarkTransportTest extends TestCase
     public function payload_has_the_proper_reply_to_address()
     {
         $this->message->setReplyTo('replyTo@example.com', 'ReplyName');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {
@@ -363,6 +375,7 @@ class PostmarkTransportTest extends TestCase
     public function empty_fields_are_not_present_in_the_json_payload()
     {
         $message = new \Swift_Message;
+
         $payload = $this->getPayload($message);
 
         tap($payload['json'], function ($json) {
@@ -378,6 +391,7 @@ class PostmarkTransportTest extends TestCase
     public function required_fields_are_present_in_the_json_payload()
     {
         $message = new \Swift_Message;
+
         $payload = $this->getPayload($message);
 
         tap($payload['json'], function ($json) {
@@ -391,6 +405,7 @@ class PostmarkTransportTest extends TestCase
     public function display_name_with_a_comma_should_be_double_quoted_the_payload()
     {
         $this->message->setTo('john@example.com', 'Doe, John');
+
         $payload = $this->getPayload($this->message);
 
         tap($payload['json'], function ($json) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,9 +16,7 @@ class TestCase extends Orchestra
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('services.postmark', [
-            'secret' => 'POSTMARK_API_TEST',
-        ]);
+        $app['config']->set('postmark.secret', 'POSTMARK_API_TEST');
     }
 
     /**

--- a/tests/TransportManagerTest.php
+++ b/tests/TransportManagerTest.php
@@ -11,6 +11,6 @@ class TransportManagerTest extends TestCase
 
         $transport = $manager->driver('postmark');
 
-        $this->assertEquals(PostmarkTransport::class, get_class($transport));
+        $this->assertInstanceOf(PostmarkTransport::class, $transport);
     }
 }


### PR DESCRIPTION
This PR adds a postmark config file.

This has two benefits:
- You don't have to add the postmark secret to `config/services.php` anymore.
- Guzzle options can be set in the config file. 

I have set the time out options for Guzzle to a more sensible default of 10 seconds instead of the previous setting of 60 seconds. 

This PR should be backwards compatible because the configuration is merged with the default config provided by this PR which will get the `POSTMARK_SECRET` from the `.env` file.