### PR TITLE
Laravel support 5.5 up to 5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Updated
+- Adds support for Laravel 5.5 up to 5.7. [`86b4b3aebd`](https://github.com/coconutcraig/laravel-postmark/commit/86b4b3aebd)
+
 ## [2.2.0] - 2018-02-19
 
 - Updates travis configuration [`ae914ea34a`](https://github.com/coconutcraig/laravel-postmark/commit/ae914ea34a) 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ $ composer require coconutcraig/laravel-postmark
 
 ## Support
 
-| Laravel | Laravel Postmark |
-|---------|------------------|
-| 5.4     | <= 2.0           |
-| 5.5     | 2.1              |
-| 5.6     | 2.2              |
+| Laravel             | Laravel Postmark |
+|---------------------|------------------|
+| 5.4.x               | <= 2.0           |
+| 5.5.x, 5.6.x, 5.7.x | => 2.2           |
 
 ## Upgrading
 

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "require": {
         "php": ">=7.1.3",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/mail": "~5.6",
-        "illuminate/support": "~5.6"
+        "illuminate/mail": "~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.6",
-        "phpunit/phpunit": "~7.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0",
+        "phpunit/phpunit": "~6.0|~7.0",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds support for Laravel 5.7.
This PR also takes care of supporting Laravel 5.5 which is a LTS release of the framework.

This package should now be compatible with all major versions of Laravel as of version 2.2.

Maybe we should drop the Support section in the README ?