### PR TITLE
Refactors the getHtmlAndTextBody() function by using a collection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Refactors the getHtmlAndTextBody() function by using a collection. [`00c36b8572`](https://github.com/coconutcraig/laravel-postmark/commit/00c36b8572)
+
 ## [2.2.0] - 2018-02-19
 
 - Updates travis configuration [`ae914ea34a`](https://github.com/coconutcraig/laravel-postmark/commit/ae914ea34a) 

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -156,29 +156,21 @@ class PostmarkTransport extends Transport
      */
     protected function getHtmlAndTextBody(Swift_Mime_SimpleMessage $message)
     {
-        $data = [];
+        $key = collect([
+            'text/html' => 'HtmlBody',
+            'multipart/mixed' => 'HtmlBody',
+            'multipart/related' => 'HtmlBody',
+            'multipart/alternative' => 'HtmlBody',
+        ])
+        ->get($message->getContentType(), 'TextBody');
 
-        switch ($message->getContentType()) {
-            case 'text/html':
-            case 'multipart/mixed':
-            case 'multipart/related':
-            case 'multipart/alternative':
-                $data['HtmlBody'] = $this->getBody($message);
-                break;
-            default:
-                $data['TextBody'] = $this->getBody($message);
-                break;
-        }
-
-        if ($text = $this->getMimePart($message, 'text/plain')) {
-            $data['TextBody'] = $text->getBody();
-        }
-
-        if ($html = $this->getMimePart($message, 'text/html')) {
-            $data['HtmlBody'] = $html->getBody();
-        }
-
-        return $data;
+        return collect([
+            $key => $this->getBody($message)
+        ])->when($this->getMimePart($message, 'text/plain'), function ($collection, $value) {
+            return $collection->put('TextBody', $value->getBody());
+        })->when($this->getMimePart($message, 'text/html'), function ($collection, $value) {
+            return $collection->put('HtmlBody', $value->getBody());
+        })->all();
     }
 
     /**

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -179,7 +179,7 @@ class PostmarkTransport extends Transport
      * @param \Swift_Mime_SimpleMessage $message
      * @param string $mimeType
      *
-     * @return \Swift_MimePart
+     * @return \Swift_MimePart|null
      */
     protected function getMimePart(Swift_Mime_SimpleMessage $message, $mimeType)
     {


### PR DESCRIPTION
- This PR refactors the getHtmlAndTextBody() function by using a collection.

- Updates the docblock for the getMimePart() function.
This function may return `null` if `$mimeType` is not found on on `$message`

- I noted that this PR introduced a minor issue:

`$this->getMimePart($message, 'text/plain')` is of type object `<Swift_MimePart>`, but the function expects a `boolean`.

This is caused by calling the `when()` function on a collection.

This function expects a boolean but the documentation says:
 "Apply the callback if the value is **truthy**."

```
    /**
     * Apply the callback if the value is truthy.
     *
     * @param  bool  $value
     * @param  callable  $callback
     * @param  callable  $default
     * @return static|mixed
     */
    public function when($value, callable $callback, callable $default = null)
```

The `when` function passes `$value` to the callback.
So I think this is more of a Laravel issue, the function should accept a mixed `$value` parameter,
and then do a check on `$value` to test if it is **truthy**. 

