### PR TITLE
Fallback to using services.postmark.sercert

### DIFF
--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -23,7 +23,7 @@ class PostmarkServiceProvider extends ServiceProvider
         $this->app['swift.transport']->extend('postmark', function () {
             return new PostmarkTransport(
                 $this->guzzle(config('postmark.guzzle', [])),
-                config('postmark.secret')
+                config('postmark.secret', config('services.postmark.secret'))
             );
         });
     }


### PR DESCRIPTION
Release 2.3.0 introduced a breaking change, there a `postmark` config is required, but normally would be load from the `services` config file. This change should have been in a 3.0 release?

This PR ensures that the secret is loaded as fallback from the old location to prevent this breaking change.