### PR TITLE
Fixes #16 - Adds build matrix to test against multiple versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
-
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.2
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+  fast_finish: true
 
 before_script:
   - composer config discard-changes true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,30 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+matrix:
+  include:
+    - php: 7.1
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+    - php: 7.1
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
+    - php: 7.1
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.2
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+    - php: 7.2
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+    - php: 7.2
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+
 before_script:
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
+  - composer config discard-changes true
+
+before_install:
+  - travis_retry composer self-update
+  - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update
+
+install:
+  - travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 script:
   - vendor/bin/phpcs --standard=psr2 src/


### PR DESCRIPTION
This PR aims to set up Travis-CI to test against the multiple supported versions of Laravel.