### PR TITLE
skip swift extension if driver isn't 'postmark'

### DIFF
--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -18,6 +18,10 @@ class PostmarkServiceProvider extends ServiceProvider
             __DIR__ . '/../config/postmark.php' => config_path('postmark.php')
         ], 'config');
 
+        if ($this->app['config']['mail.driver'] != 'postmark') {
+            return;
+        }
+
         $this->mergeConfigFrom(__DIR__ . '/../config/postmark.php', 'postmark');
 
         $this->app['swift.transport']->extend('postmark', function () {

--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -18,7 +18,7 @@ class PostmarkServiceProvider extends ServiceProvider
             __DIR__ . '/../config/postmark.php' => config_path('postmark.php')
         ], 'config');
 
-        if ($this->app['config']['mail.driver'] != 'postmark') {
+        if ($this->app['config']['mail.driver'] !== 'postmark') {
             return;
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,8 @@
 
 namespace Coconuts\Mail;
 
-use ReflectionClass;
 use Orchestra\Testbench\TestCase as Orchestra;
+use ReflectionClass;
 
 class TestCase extends Orchestra
 {
@@ -16,6 +16,7 @@ class TestCase extends Orchestra
      */
     protected function getEnvironmentSetUp($app)
     {
+        $app['config']->set('mail.driver', 'postmark');
         $app['config']->set('postmark.secret', 'POSTMARK_API_TEST');
     }
 


### PR DESCRIPTION
If the mail driver isn't set to 'postmark', don't register the Postmark transport for Swift.

## Motivation and context

First of all this skips a bit of unnecessary code, but it also enables a developer to use this package in combination with other mail drivers in different environments.
For example, when combined with the 'themsaid/laravel-mail-preview' package, the artisan package:discover command would fail with a `Class swift.transport does not exist` error.
