### PR TITLE
Support for Laravel 5.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,24 @@ matrix:
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
     - php: 7.1
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.1
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.2
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.2
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
     - php: 7.2
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.3
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.3
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
     - php: 7.3
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
   fast_finish: true
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 - Adds test to ensure custom creator is not put into framework when mail driver is not postmark [`7c22b536f6`](https://github.com/coconutcraig/laravel-postmark/commit/7c22b536f6)
 
-## [2.3.1] - 2018-09-27
+## [2.3.3] - 2019-02-26
+
+### Added
+- Adds support for Laravel 5.8 [`#26`](https://github.com/craigpaul/laravel-postmark/pull/26) 
+
+## [2.3.2] - 2018-09-27
 
 ### Added
 - Adds build matrix to test against multiple versions. [`ea0b27d9f7`](https://github.com/coconutcraig/laravel-postmark/commit/ea0b27d9f7) 
@@ -205,7 +210,8 @@
 ### Added
 - Adds package skeleton. [`2f6fe84bcc`](https://github.com/coconutcraig/laravel-postmark/commit/2f6fe84bcc)
 
-[Unreleased]: https://github.com/coconutcraig/laravel-postmark/compare/v2.3.2...HEAD
+[Unreleased]: https://github.com/coconutcraig/laravel-postmark/compare/v2.3.3...HEAD
+[2.3.3]: https://github.com/coconutcraig/laravel-postmark/compare/v2.3.2...2.3.3
 [2.3.2]: https://github.com/coconutcraig/laravel-postmark/compare/v2.3.1...2.3.2
 [2.3.1]: https://github.com/coconutcraig/laravel-postmark/compare/v2.3.0...2.3.1
 [2.3.0]: https://github.com/coconutcraig/laravel-postmark/compare/v2.2.0...2.3.0

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     "require": {
         "php": ">=7.1.3",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/mail": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0"
+        "illuminate/mail": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
         "phpunit/phpunit": "~6.0|~7.0",
         "squizlabs/php_codesniffer": "^3.0"
     },

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -22,7 +22,7 @@ class PostmarkTransportTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Laravel 5.8 released today.

This PR adds support for L5.8.

Note that Taylor added support for Postmark, see the [docs](https://laravel.com/docs/5.8/mail#introduction) and his [commit](https://github.com/laravel/framework/commit/b176ecc937c587534837869e517b1daa20659054#diff-025006b2c4889f2136ad802e7ee2f622).