### PR TITLE
Add support for postmark custom metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ public function build()
 }
 ```
 
+## Postmark Metadata
+
+Similar to tags, you can also include [metadata](https://postmarkapp.com/support/article/1125-custom-metadata-faq) by adding a header. Metadata headers should be prefixed with `metadata-` where the string that follows is the metadata key.
+
+```php
+public function build()
+{
+    $this->withSwiftMessage(function (\Swift_Message $message) {
+        $message->getHeaders()->addTextHeader('metadata-field', 'value');
+        $message->getHeaders()->addTextHeader('metadata-another-field', 'another value');
+    });
+}
+```
+
+In this case, the following object will be sent to Postmark as metadata.
+
+```
+{
+    "field": "value",
+    "another-field", "another value"
+}
+```
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -223,12 +223,12 @@ class PostmarkTransport extends Transport
     protected function getMetadata(Swift_Mime_SimpleMessage $message)
     {
         return collect($message->getHeaders()->getAll())
-        ->mapWithKeys(function($header){
+        ->mapWithKeys(function ($header) {
             mb_ereg('^metadata-(.*)', $header->getFieldName(), $matches);
 
             return isset($matches[1]) && $matches[1] !== false
             ? [
-                $matches[1] => iconv_mime_decode($header->getFieldBody(), 0, 'UTF-8')
+                $matches[1] => iconv_mime_decode($header->getFieldBody(), 0, 'UTF-8'),
             ]
             : ['' => null];
         })

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -447,7 +447,7 @@ class PostmarkTransportTest extends TestCase
 
         $this->assertSame([
             'metadata' => 'metadata',
-            'other-data' => 'some other data'
+            'other-data' => 'some other data',
         ], $metadata);
     }
 
@@ -468,7 +468,7 @@ class PostmarkTransportTest extends TestCase
         $metadata = $this->invokeMethod($this->transport, 'getMetadata', [$message]);
 
         $this->assertSame([
-            'other-data¹' => 'some other data¹'
+            'other-data¹' => 'some other data¹',
         ], $metadata);
     }
 }


### PR DESCRIPTION
Postmark allows you to send [custom metadata](https://postmarkapp.com/support/article/1125-custom-metadata-faq) along with new emails which I've found useful. This adds support for that and is implemented similar to tags.