### PR TITLE
Update doc blocks

### DIFF
--- a/src/MailMessage.php
+++ b/src/MailMessage.php
@@ -30,7 +30,6 @@ class MailMessage extends Message
      * Set the template alias.
      *
      * @param  string  $alias
-     *
      * @return $this
      */
     public function alias($alias)
@@ -58,7 +57,6 @@ class MailMessage extends Message
      * Set the template identifier.
      *
      * @param  int  $id
-     *
      * @return $this
      */
     public function identifier($id)
@@ -72,7 +70,6 @@ class MailMessage extends Message
      * Set the data to be available within the template.
      *
      * @param  array  $data
-     *
      * @return $this
      */
     public function include($data)

--- a/src/MailMessage.php
+++ b/src/MailMessage.php
@@ -29,7 +29,7 @@ class MailMessage extends Message
     /**
      * Set the template alias.
      *
-     * @param string $alias
+     * @param  string  $alias
      *
      * @return $this
      */
@@ -57,7 +57,7 @@ class MailMessage extends Message
     /**
      * Set the template identifier.
      *
-     * @param int $id
+     * @param  int  $id
      *
      * @return $this
      */
@@ -71,7 +71,7 @@ class MailMessage extends Message
     /**
      * Set the data to be available within the template.
      *
-     * @param array $data
+     * @param  array  $data
      *
      * @return $this
      */

--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -38,7 +38,6 @@ class PostmarkServiceProvider extends ServiceProvider
      * Get a fresh Guzzle HTTP client instance.
      *
      * @param  array  $config
-     *
      * @return \GuzzleHttp\Client
      */
     protected function guzzle($config)

--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -37,7 +37,7 @@ class PostmarkServiceProvider extends ServiceProvider
     /**
      * Get a fresh Guzzle HTTP client instance.
      *
-     * @param array $config
+     * @param  array  $config
      *
      * @return \GuzzleHttp\Client
      */

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -40,8 +40,8 @@ class PostmarkTransport extends Transport
      *
      * @param  \GuzzleHttp\ClientInterface  $client
      * @param  string  $key
-     *
      * @return void
+     *
      * @throws \Coconuts\Mail\Exceptions\PostmarkException
      */
     public function __construct(ClientInterface $client, $key)
@@ -81,7 +81,6 @@ class PostmarkTransport extends Transport
      * Get all attachments for the given message.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return array
      */
     protected function getAttachments(Swift_Mime_SimpleMessage $message)
@@ -105,7 +104,6 @@ class PostmarkTransport extends Transport
      * Format the display name.
      *
      * @param  string  $value
-     *
      * @return string
      */
     protected function getDisplayName($value)
@@ -121,7 +119,6 @@ class PostmarkTransport extends Transport
      * Format the contacts for the API request.
      *
      * @param  string|array  $contacts
-     *
      * @return string
      */
     protected function getContacts($contacts)
@@ -138,7 +135,6 @@ class PostmarkTransport extends Transport
      * Get the message ID from the response.
      *
      * @param  \GuzzleHttp\Psr7\Response  $response
-     *
      * @return string
      */
     protected function getMessageId($response)
@@ -153,7 +149,6 @@ class PostmarkTransport extends Transport
      * Get the body for the given message.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return string
      */
     protected function getBody(Swift_Mime_SimpleMessage $message)
@@ -165,7 +160,6 @@ class PostmarkTransport extends Transport
      * Get the text and html fields for the given message.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return array
      */
     protected function getHtmlAndTextBody(Swift_Mime_SimpleMessage $message)
@@ -194,7 +188,6 @@ class PostmarkTransport extends Transport
      *
      * @param  \Swift_Mime_SimpleMessage  $message
      * @param  string  $mimeType
-     *
      * @return \Swift_MimePart|null
      */
     protected function getMimePart(Swift_Mime_SimpleMessage $message, $mimeType)
@@ -213,7 +206,6 @@ class PostmarkTransport extends Transport
      * Get the subject for the given message.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return string
      */
     protected function getSubject(Swift_Mime_SimpleMessage $message)
@@ -225,7 +217,6 @@ class PostmarkTransport extends Transport
      * Get metadata for the given message.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return array
      */
     protected function getMetadata(Swift_Mime_SimpleMessage $message)
@@ -246,7 +237,6 @@ class PostmarkTransport extends Transport
      * Get the tag for the given message.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return string
      */
     protected function getTag(Swift_Mime_SimpleMessage $message)
@@ -260,7 +250,6 @@ class PostmarkTransport extends Transport
      * Get the HTTP payload for sending the Postmark message.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return array
      */
     protected function payload(Swift_Mime_SimpleMessage $message)
@@ -315,7 +304,6 @@ class PostmarkTransport extends Transport
      * Determine if the given message is wanting to use the Postmark Template API.
      *
      * @param  \Swift_Mime_SimpleMessage  $message
-     *
      * @return array|null
      */
     protected function templated(Swift_Mime_SimpleMessage $message)

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -293,7 +293,7 @@ class PostmarkTransport extends Transport
                         return $collection
                             ->merge($this->getHtmlAndTextBody($message))
                             ->merge(['Subject' => $this->getSubject($message)]);
-                    })
+                    }),
             ])
             ->toArray();
 

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -38,8 +38,8 @@ class PostmarkTransport extends Transport
     /**
      * Create a new Postmark transport instance.
      *
-     * @param \GuzzleHttp\ClientInterface $client
-     * @param string $key
+     * @param  \GuzzleHttp\ClientInterface  $client
+     * @param  string  $key
      *
      * @return void
      * @throws \Coconuts\Mail\Exceptions\PostmarkException
@@ -80,7 +80,7 @@ class PostmarkTransport extends Transport
     /**
      * Get all attachments for the given message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return array
      */
@@ -120,7 +120,7 @@ class PostmarkTransport extends Transport
     /**
      * Format the contacts for the API request.
      *
-     * @param string|array $contacts
+     * @param  string|array  $contacts
      *
      * @return string
      */
@@ -137,7 +137,7 @@ class PostmarkTransport extends Transport
     /**
      * Get the message ID from the response.
      *
-     * @param \GuzzleHttp\Psr7\Response $response
+     * @param  \GuzzleHttp\Psr7\Response  $response
      *
      * @return string
      */
@@ -152,7 +152,7 @@ class PostmarkTransport extends Transport
     /**
      * Get the body for the given message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return string
      */
@@ -164,7 +164,7 @@ class PostmarkTransport extends Transport
     /**
      * Get the text and html fields for the given message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return array
      */
@@ -192,8 +192,8 @@ class PostmarkTransport extends Transport
     /**
      * Get a mime part from the given message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
-     * @param string $mimeType
+     * @param  \Swift_Mime_SimpleMessage  $message
+     * @param  string  $mimeType
      *
      * @return \Swift_MimePart|null
      */
@@ -212,7 +212,7 @@ class PostmarkTransport extends Transport
     /**
      * Get the subject for the given message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return string
      */
@@ -224,7 +224,7 @@ class PostmarkTransport extends Transport
     /**
      * Get metadata for the given message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return array
      */
@@ -245,7 +245,7 @@ class PostmarkTransport extends Transport
     /**
      * Get the tag for the given message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return string
      */
@@ -259,7 +259,7 @@ class PostmarkTransport extends Transport
     /**
      * Get the HTTP payload for sending the Postmark message.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return array
      */
@@ -314,7 +314,7 @@ class PostmarkTransport extends Transport
     /**
      * Determine if the given message is wanting to use the Postmark Template API.
      *
-     * @param \Swift_Mime_SimpleMessage $message
+     * @param  \Swift_Mime_SimpleMessage  $message
      *
      * @return array|null
      */

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -104,7 +104,7 @@ class PostmarkTransport extends Transport
     /**
      * Format the display name.
      *
-     * @param  string
+     * @param  string  $value
      *
      * @return string
      */

--- a/tests/PostmarkServiceProviderTest.php
+++ b/tests/PostmarkServiceProviderTest.php
@@ -17,7 +17,6 @@ class PostmarkServiceProviderTest extends TestCase
     /**
      * Get package providers.
      *
-     *
      * @param  \Illuminate\Foundation\Application  $app
      * @return array
      */

--- a/tests/PostmarkServiceProviderTest.php
+++ b/tests/PostmarkServiceProviderTest.php
@@ -17,8 +17,8 @@ class PostmarkServiceProviderTest extends TestCase
     /**
      * Get package providers.
      *
-     * @param \Illuminate\Foundation\Application $app
      *
+     * @param  \Illuminate\Foundation\Application  $app
      * @return array
      */
     protected function getPackageProviders($app)

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -55,7 +55,7 @@ class PostmarkTransportTest extends TestCase
     /**
      * Get the json payload for the given message.
      *
-     * @param  \Swift_Message $message
+     * @param  \Swift_Message  $message
      *
      * @return string
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,6 @@ class TestCase extends Orchestra
      * Define environment setup.
      *
      * @param  \Illuminate\Foundation\Application  $app
-     *
      * @return void
      */
     protected function getEnvironmentSetUp($app)
@@ -24,7 +23,6 @@ class TestCase extends Orchestra
      * Get package providers.
      *
      * @param  \Illuminate\Foundation\Application  $app
-     *
      * @return array
      */
     protected function getPackageProviders($app)
@@ -38,8 +36,8 @@ class TestCase extends Orchestra
      * @param  mixed  $object
      * @param  string  $name
      * @param  array  $params
-     *
      * @return mixed
+     *
      * @throws \ReflectionException
      */
     protected function invokeMethod(&$object, $name, array $params = [])
@@ -56,8 +54,8 @@ class TestCase extends Orchestra
      *
      * @param  mixed  $object
      * @param  string  $name
-     *
      * @return mixed
+     *
      * @throws \ReflectionException
      */
     protected function readProperty(&$object, $name)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ class TestCase extends Orchestra
     /**
      * Define environment setup.
      *
-     * @param \Illuminate\Foundation\Application $app
+     * @param  \Illuminate\Foundation\Application  $app
      *
      * @return void
      */
@@ -23,7 +23,7 @@ class TestCase extends Orchestra
     /**
      * Get package providers.
      *
-     * @param \Illuminate\Foundation\Application $app
+     * @param  \Illuminate\Foundation\Application  $app
      *
      * @return array
      */
@@ -35,9 +35,9 @@ class TestCase extends Orchestra
     /**
      * Invoke a non-public method.
      *
-     * @param mixed $object
-     * @param string $name
-     * @param array $params
+     * @param  mixed  $object
+     * @param  string  $name
+     * @param  array  $params
      *
      * @return mixed
      * @throws \ReflectionException
@@ -54,8 +54,8 @@ class TestCase extends Orchestra
     /**
      * Read a non-public property.
      *
-     * @param mixed $object
-     * @param string $name
+     * @param  mixed  $object
+     * @param  string  $name
      *
      * @return mixed
      * @throws \ReflectionException


### PR DESCRIPTION
Laravel [follows this convention](https://laravel.com/docs/5.8/contributions#coding-style) for the docblocks:

> the @param attribute is followed by two spaces, the argument type, two more spaces, and finally the variable name

There is no empty line between `@param` and `@return`.

This PR updates the doc blocks to follow the same convention.