### PR TITLE
Updates version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Updated version contraints for Laravel 6.0. [`2ca003724f`](https://github.com/coconutcraig/laravel-postmark/commit/2ca003724f)
 - Applies suggested change from style-ci [`c0cdf3cdfe`](https://github.com/coconutcraig/laravel-postmark/commit/c0cdf3cdfe)
 - Removes empty lines between @param and @return. [`012247f519`](https://github.com/coconutcraig/laravel-postmark/commit/012247f519)
 - Adds double spaces to the doc blocks. [`6365c7d56b`](https://github.com/coconutcraig/laravel-postmark/commit/6365c7d56b)

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "php": ">=7.1.3",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/mail": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0"
+        "illuminate/mail": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",


### PR DESCRIPTION
This PR updates the version constraints to support Laravel 6.0 which will be released in a few weeks.