### PR TITLE
Style CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ install:
   - travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 script:
-  - vendor/bin/phpcs --standard=psr2 src/
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/coconut
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - Check the code style with ``$ composer check-style`` and fix it with ``$ composer fix-style``.
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](https://pear.php.net/package/PHP_CodeSniffer).
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 

--- a/README.md
+++ b/README.md
@@ -129,14 +129,14 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 [ico-version]: https://img.shields.io/packagist/v/coconutcraig/laravel-postmark.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
 [ico-travis]: https://img.shields.io/travis/craigpaul/laravel-postmark/master.svg?style=flat-square
-[ico-style-ci]: https://styleci.io/repos/{id}/shield?branch=master[
+[ico-style-ci]: https://styleci.io/repos/80351847/shield?branch=master
 ico-scrutinizer]: https://img.shields.io/scrutinizer/coverage/g/coconutcraig/laravel-postmark.svg?style=flat-square
 [ico-code-quality]: https://img.shields.io/scrutinizer/g/coconutcraig/laravel-postmark.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/coconutcraig/laravel-postmark.svg?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/coconutcraig/laravel-postmark
 [link-travis]: https://travis-ci.com/craigpaul/laravel-postmark
-[link-style-ci]: https://styleci.io/repos/{id}
+[link-style-ci]: https://styleci.io/repos/80351847
 [link-scrutinizer]: https://scrutinizer-ci.com/g/coconutcraig/laravel-postmark/code-structure
 [link-code-quality]: https://scrutinizer-ci.com/g/coconutcraig/laravel-postmark
 [link-downloads]: https://packagist.org/packages/coconutcraig/laravel-postmark

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Build Status][ico-travis]][link-travis]
 [![Coverage Status][ico-scrutinizer]][link-scrutinizer]
 [![Quality Score][ico-code-quality]][link-code-quality]
+[![StyleCI][ico-style-ci]][link-style-ci]
 [![Total Downloads][ico-downloads]][link-downloads]
 
 > [Postmark](https://postmarkapp.com) is the easiest and most reliable way to be sure your important transactional emails get to your customer's inbox.
@@ -128,12 +129,14 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 [ico-version]: https://img.shields.io/packagist/v/coconutcraig/laravel-postmark.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
 [ico-travis]: https://img.shields.io/travis/craigpaul/laravel-postmark/master.svg?style=flat-square
-[ico-scrutinizer]: https://img.shields.io/scrutinizer/coverage/g/coconutcraig/laravel-postmark.svg?style=flat-square
+[ico-style-ci]: https://styleci.io/repos/{id}/shield?branch=master[
+ico-scrutinizer]: https://img.shields.io/scrutinizer/coverage/g/coconutcraig/laravel-postmark.svg?style=flat-square
 [ico-code-quality]: https://img.shields.io/scrutinizer/g/coconutcraig/laravel-postmark.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/coconutcraig/laravel-postmark.svg?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/coconutcraig/laravel-postmark
 [link-travis]: https://travis-ci.com/craigpaul/laravel-postmark
+[link-style-ci]: https://styleci.io/repos/{id}
 [link-scrutinizer]: https://scrutinizer-ci.com/g/coconutcraig/laravel-postmark/code-structure
 [link-code-quality]: https://scrutinizer-ci.com/g/coconutcraig/laravel-postmark
 [link-downloads]: https://packagist.org/packages/coconutcraig/laravel-postmark

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "vendor/bin/phpunit",
     },
     "suggest": {
         "mvdnbrk/postmark-inbound": "Allows you to process Postmark Inbound Webhooks."

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
+        "test": "vendor/bin/phpunit"
     },
     "suggest": {
         "mvdnbrk/postmark-inbound": "Allows you to process Postmark Inbound Webhooks."

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0|~3.9.0",
         "phpunit/phpunit": "~6.0|~7.0|~8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
-        "phpunit/phpunit": "~6.0|~7.0"
+        "phpunit/phpunit": "~6.0|~7.0|~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
-        "phpunit/phpunit": "~6.0|~7.0",
+        "phpunit/phpunit": "~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "require-dev": {
         "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
         "phpunit/phpunit": "~6.0|~7.0",
-        "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -44,8 +43,6 @@
     },
     "scripts": {
         "test": "phpunit",
-        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
     },
     "suggest": {
         "mvdnbrk/postmark-inbound": "Allows you to process Postmark Inbound Webhooks."


### PR DESCRIPTION
We have a `.styleci.yml` file but the badge is missing.
This PR adds the StyleCI badge. Please replace `{id}` with the actual id from StyleCI.

@craigpaul Is [StyleCI](https://styleci.io) already enabled for this repo?

If enabled, we can remove PHP_CodeSniffer as a dev dependency and let StyleCI take care of code styling issues.