### PR TITLE
Alpha ordered imports

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,5 @@
 preset: laravel
+enabled:
+  - alpha_ordered_imports
+disabled:
+  - length_ordered_imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Sort imports in alphabetical order. [`#45`](https://github.com/craigpaul/laravel-postmark/pull/45)
+
 ## [2.6.0] - 2019-09-03
 
 ### Changed

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -2,15 +2,15 @@
 
 namespace Coconuts\Mail;
 
-use Swift_MimePart;
-use function collect;
-use Swift_Attachment;
-use function json_decode;
-use Swift_Mime_SimpleMessage;
-use GuzzleHttp\ClientInterface;
-use Illuminate\Support\Collection;
-use Illuminate\Mail\Transport\Transport;
 use Coconuts\Mail\Exceptions\PostmarkException;
+use function collect;
+use GuzzleHttp\ClientInterface;
+use Illuminate\Mail\Transport\Transport;
+use Illuminate\Support\Collection;
+use function json_decode;
+use Swift_Attachment;
+use Swift_Mime_SimpleMessage;
+use Swift_MimePart;
 
 class PostmarkTransport extends Transport
 {

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -2,14 +2,14 @@
 
 namespace Coconuts\Mail\Tests;
 
-use function tap;
-use Swift_Message;
-use Swift_Attachment;
-use GuzzleHttp\Client;
-use function json_encode;
-use Coconuts\Mail\PostmarkTransport;
-use GuzzleHttp\Exception\RequestException;
 use Coconuts\Mail\Exceptions\PostmarkException;
+use Coconuts\Mail\PostmarkTransport;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use function json_encode;
+use Swift_Attachment;
+use Swift_Message;
+use function tap;
 
 class PostmarkTransportTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,9 @@
 
 namespace Coconuts\Mail\Tests;
 
-use ReflectionClass;
 use Coconuts\Mail\PostmarkServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use ReflectionClass;
 
 class TestCase extends Orchestra
 {


### PR DESCRIPTION
As of Laravel v6 imports are sorted alphabetically.
