### PR TITLE
Update testbench version and travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - php: 7.2
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.2
-      env: LARAVEL='6.0.*' TESTBENCH='3.9.*'
+      env: LARAVEL='6.*' TESTBENCH='4.*'
     - php: 7.3
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.3
@@ -38,7 +38,7 @@ matrix:
     - php: 7.3
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.3
-      env: LARAVEL='6.0.*' TESTBENCH='3.9.*'
+      env: LARAVEL='6.*' TESTBENCH='4.*'
   fast_finish: true
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*'
+    - php: 7.4
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
+    - php: 7.4
+      env: LARAVEL='6.*' TESTBENCH='4.*'
   fast_finish: true
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0|~3.9.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0|^4.0",
         "phpunit/phpunit": "~6.0|~7.0|~8.0"
     },
     "autoload": {


### PR DESCRIPTION
We should use `orchestra/testbench` v4 to test against Laravel 6.
Updated `.travis.yml` accordingly.

Updated to test against PHP 7.4 as well.