### PR TITLE
Change to caret notation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
+        "php": "^7.1.3",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "~6.0",
-        "illuminate/mail": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0",
-        "illuminate/support": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0"
+        "guzzlehttp/guzzle": "^6.0",
+        "illuminate/mail": "^5.5 || ^6.0",
+        "illuminate/support": "^5.5 || ^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5.0 || ~3.6.0 || ~3.7.0 || ~3.8.0 || ^4.0",
-        "phpunit/phpunit": "~6.0 || ~7.0 || ~8.0"
+        "orchestra/testbench": "^3.5 || ^4.0",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"
     },
     "suggest": {
         "mvdnbrk/postmark-inbound": "Allows you to process Postmark Inbound Webhooks."


### PR DESCRIPTION
https://getcomposer.org/doc/articles/versions.md#caret-version-range-
> This is the recommended operator for maximum interoperability when writing library code.
