### PR TITLE
Use postmark-config tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The package will automatically register itself.
 You can optionally publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Coconuts\Mail\PostmarkServiceProvider" --tag="config"
+php artisan vendor:publish --tag="postmark-config"
 ```
 
 ## Usage

--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -18,7 +18,7 @@ class PostmarkServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../config/postmark.php' => config_path('postmark.php'),
-        ], 'config');
+        ], 'postmark-config');
 
         if ($this->app['config']['mail.driver'] !== 'postmark') {
             return;


### PR DESCRIPTION
This PR simplifies the `vendor:publish` command.

Running `php artisan vendor:publish` provides a tag number to choose from to publish the `postmark-config` file.