### PR TITLE
Add Guzzle v7.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Adds support for Guzzle 7.0. [`#62`](https://github.com/craigpaul/laravel-postmark/pull/62)
+
 ## [2.7.1] - 2019-11-08
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.1.3",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "illuminate/mail": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0",
         "illuminate/support": "~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0"
     },


### PR DESCRIPTION
Guzzle will release a ^7.0 version soon (beta version has already been [tagged](https://github.com/guzzle/guzzle/releases/tag/7.0.0-beta.1)).
We should support this version.