### PR TITLE
Refactor to registerPostmarkDriver

### DIFF
--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -20,11 +20,21 @@ class PostmarkServiceProvider extends ServiceProvider
             __DIR__.'/../config/postmark.php' => config_path('postmark.php'),
         ], 'postmark-config');
 
-        if ($this->app['config']['mail.driver'] !== 'postmark') {
+        $this->mergeConfigFrom(__DIR__.'/../config/postmark.php', 'postmark');
+
+        $this->registerPostmarkDriver();
+    }
+
+    /**
+     * Register the Postmark driver.
+     *
+     * @return void
+     */
+    private function registerPostmarkDriver()
+    {
+        if (! $this->shouldRegisterPostmarkDriver()) {
             return;
         }
-
-        $this->mergeConfigFrom(__DIR__.'/../config/postmark.php', 'postmark');
 
         $this->app['swift.transport']->extend('postmark', function () {
             return new PostmarkTransport(
@@ -32,6 +42,16 @@ class PostmarkServiceProvider extends ServiceProvider
                 config('postmark.secret', config('services.postmark.secret'))
             );
         });
+    }
+
+    /**
+     * Determine if we should register the Postmark driver.
+     *
+     * @return bool
+     */
+    protected function shouldRegisterPostmarkDriver()
+    {
+        return $this->app['config']['mail.driver'] === 'postmark';
     }
 
     /**


### PR DESCRIPTION
Extracted the registration of the Postmark driver to it's own method.

Added  a `shouldRegisterPostmarkDriver` method.

Related to issue #58 we could add an additional version check to always register the Postmark driver for Laravel 7.