### PR TITLE
Add Laravel 7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.2
       env: LARAVEL='6.*' TESTBENCH='4.*'
+    - php: 7.2
+      env: LARAVEL='7.*' TESTBENCH='5.*'
     - php: 7.3
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.3
@@ -39,10 +41,14 @@ matrix:
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*'
+    - php: 7.3
+      env: LARAVEL='7.*' TESTBENCH='5.*'
     - php: 7.4
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.4
       env: LARAVEL='6.*' TESTBENCH='4.*'
+    - php: 7.4
+      env: LARAVEL='7.*' TESTBENCH='5.*'
   fast_finish: true
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Adds support for Laravel 7.0 [`#65`](https://github.com/craigpaul/laravel-postmark/pull/65)
+
 ## [2.7.1] - 2019-11-08
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
         "php": "^7.1.3",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0",
-        "illuminate/mail": "^5.5 || ^6.0",
-        "illuminate/support": "^5.5 || ^6.0"
+        "illuminate/mail": "^5.5 || ^6.0 || ^7.0",
+        "illuminate/support": "^5.5 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.5 || ^4.0",
+        "orchestra/testbench": "^3.5 || ^4.0 || ^5.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"
     },
     "suggest": {


### PR DESCRIPTION
Tests against Laravel v7.0 are failing:

```
Illuminate\Contracts\Container\BindingResolutionException: Target class [swift.transport] does not exist.
```