### PR TITLE
Removes scrutinizer/ocular package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,5 @@ script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.5 || ^4.0",
-        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "scrutinizer/ocular": "^1.6"
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "suggest": {
         "mvdnbrk/postmark-inbound": "Allows you to process Postmark Inbound Webhooks."


### PR DESCRIPTION
`scrutinizer/ocular` seems not to be compatible with Symfony 5.

See https://github.com/scrutinizer-ci/ocular/issues/47