### PR TITLE
Fixes docblock.

### DIFF
--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -71,7 +71,13 @@ class PostmarkTransport extends Transport
     }
 
     /**
-     * {@inheritdoc}
+     * Send the given Message.
+     *
+     * @param  Swift_Mime_SimpleMessage  $message
+     * @param  array  $failedRecipients
+     * @return int
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -71,7 +71,7 @@ class PostmarkTransport extends Transport
     }
 
     /**
-     * Send the given Message.
+     * Send the given message.
      *
      * @param  Swift_Mime_SimpleMessage  $message
      * @param  array  $failedRecipients


### PR DESCRIPTION
We are extending from the `Transport` class and overriding the `send` method.

A request made with Guzzle may throw a `GuzzleException`.