### PR TITLE
Add support for Laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,16 @@ matrix:
       env: LARAVEL='6.*' TESTBENCH='4.*'
     - php: 7.3
       env: LARAVEL='7.*' TESTBENCH='5.*'
+    - php: 7.3
+      env: LARAVEL='8.*' TESTBENCH='6.*'
     - php: 7.4
       env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.4
       env: LARAVEL='6.*' TESTBENCH='4.*'
     - php: 7.4
       env: LARAVEL='7.*' TESTBENCH='5.*'
+    - php: 7.4
+      env: LARAVEL='8.*' TESTBENCH='6.*'
   fast_finish: true
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Adds support for Laravel 8.0. [`#82`](https://github.com/craigpaul/laravel-postmark/pull/82)
+
 ## [2.8.2] - 2020-03-04
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
         "php": "^7.1.3",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
-        "illuminate/mail": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0"
+        "illuminate/mail": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.5 || ^4.0 || ^5.0",
+        "orchestra/testbench": "^3.5 || ^4.0 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "suggest": {


### PR DESCRIPTION
Laravel 8 is announced to be released on september 8th.

This PR adds support for this release.