### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email craig.paul@coconutcalendar.com instead of using the issue tracker.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center"><a href="https://postmarkapp.com" target="_blank"><img src="https://postmarkapp.com/images/logo.svg" alt="Postmark" width="240" height="40"></a>
-    
+
 # Laravel Postmark
 
 [![Latest Version on Packagist][ico-version]][link-packagist]
@@ -115,9 +115,9 @@ $ composer test
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) and [CONDUCT](.github/CODE_OF_CONDUCT.md) for details.
 
-## Security
+## Security Vulnerabilities
 
-If you discover any security related issues, please email craig.paul@coconutcalendar.com instead of using the issue tracker.
+Please review our [security policy](.github/SECURITY.md) on how to report security vulnerabilities.
 
 ## Credits
 


### PR DESCRIPTION
Created a `.github/SECURITY.md` file, this will be visible under the **Security** tab of the repo.