### PR TITLE
Resubmit of #86 (security policy)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,3 +1,3 @@
 # Security Policy
 
-If you discover any security related issues, please email craig.paul@coconutcalendar.com instead of using the issue tracker.
+If you discover any security related issues, please email craig.paul@coconutsoftware.com instead of using the issue tracker.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email craig.paul@coconutcalendar.com instead of using the issue tracker.

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ $ composer test
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) and [CONDUCT](.github/CODE_OF_CONDUCT.md) for details.
 
-## Security
+## Security Vulnerabilities
 
-If you discover any security related issues, please email craig.paul@coconutcalendar.com instead of using the issue tracker.
+Please review our [security policy](.github/SECURITY.md) on how to report security vulnerabilities.
 
 ## Credits
 


### PR DESCRIPTION
Resubmitting #86. No clue why this got lost but can't find it on the main branch nor on the 2.x branch.