### PR TITLE
[2.x] Use request method on ClientInterface

### DIFF
--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -60,7 +60,11 @@ class PostmarkTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $response = $this->client->post($this->getApiEndpoint($message), $this->payload($message));
+        $response = $this->client->request(
+            'POST',
+            $this->getApiEndpoint($message),
+            $this->payload($message)
+        );
 
         $message->getHeaders()->addTextHeader(
             'X-PM-Message-Id',


### PR DESCRIPTION
The `post` method does not exist on `GuzzleHttp\ClientInterface`.

Changed this to use the proper `request` method on the `ClientInterface`.