### PR TITLE
Remove duplicate call to `mergeConfigFrom` method

### DIFF
--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -23,7 +23,6 @@ class PostmarkServiceProvider extends ServiceProvider
         }
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'postmark');
-        $this->mergeConfigFrom(__DIR__.'/../config/postmark.php', 'postmark');
 
         $this->resolveTransportManager()->extend('postmark', function () {
             return new PostmarkTransport(


### PR DESCRIPTION
The `mergeConfigFrom` method is called twice:

- in the `boot` method
- in the `registerPostmarkDriver` method which is called from the `boot` method

Removed the duplicate call in the `registerPostmarkDriver` method