### PR TITLE
[2.x] Add X-Message-ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- `X-Message-ID` header to a sent message [`#119`](https://github.com/craigpaul/laravel-postmark/pull/119)
+- `X-Message-ID` header to sent messages. [`#119`](https://github.com/craigpaul/laravel-postmark/pull/119)
 - Support for PHP 8. [`#117`](https://github.com/craigpaul/laravel-postmark/pull/117)
 
 ## [2.9.1] - 2020-10-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `X-Message-ID` header to a sent message [`#119`](https://github.com/craigpaul/laravel-postmark/pull/119)
 - Support for PHP 8. [`#117`](https://github.com/craigpaul/laravel-postmark/pull/117)
 
 ## [2.9.1] - 2020-10-29

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -67,10 +67,10 @@ class PostmarkTransport extends Transport
             $this->payload($message)
         );
 
-        $message->getHeaders()->addTextHeader(
-            'X-PM-Message-Id',
-            $this->getMessageId($response)
-        );
+        $messageId = $this->getMessageId($response);
+
+        $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
+        $message->getHeaders()->addTextHeader('X-PM-Message-Id', $messageId);
 
         $this->sendPerformed($message);
 

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -473,6 +473,7 @@ class PostmarkTransportTest extends TestCase
     {
         try {
             $this->transport->send($this->message);
+            $this->assertNotNull($this->message->getHeaders()->get('X-Message-ID'));
             $this->assertNotNull($this->message->getHeaders()->get('X-PM-Message-Id'));
         } catch (RequestException $e) {
             $this->fail($e->getMessage());


### PR DESCRIPTION
Add `X-Message-ID` header to a sent message.

 The `X-PM-Message-Id` can be removed in the next major release.

See laravel/framework#34567