### PR TITLE
[3.x] Use X-Message-ID in headers of sent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Support for PHP 8 [#115](https://github.com/craigpaul/laravel-postmark/pull/115)
 
+### Removed
+- `X-PM-Message-Id` header from sent messages in favor of `X-Message-ID`. [#121](https://github.com/craigpaul/laravel-postmark/pull/121)
+
 ## [2.9.1] - 2020-10-29
 
 ### Changed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade Guide
 
+## From v2.x to v3.0
+
+- The `X-PM-Message-Id` header was removed from sent messages. You should update this to `X-Message-ID`.
+
 ## From v2.2 to v2.3
 
 You may remove the `postmark` specific key from  the `config/services.php` file.

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -65,7 +65,7 @@ class PostmarkTransport extends Transport
         );
 
         $message->getHeaders()->addTextHeader(
-            'X-PM-Message-Id',
+            'X-Message-ID',
             $this->getMessageId($response)
         );
 

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -471,7 +471,7 @@ class PostmarkTransportTest extends TestCase
     {
         try {
             $this->transport->send($this->message);
-            $this->assertNotNull($this->message->getHeaders()->get('X-PM-Message-Id'));
+            $this->assertNotNull($this->message->getHeaders()->get('X-Message-ID'));
         } catch (RequestException $e) {
             $this->fail($e->getMessage());
         }


### PR DESCRIPTION
Resolves issue #120 

Related to #119

Removed `X-PM-Message-Id` header from sent messages in favor of `X-Message-ID`.