### PR TITLE
Adds ability to toggle between temporary testing endpoint and real endpoint

### DIFF
--- a/config/postmark.php
+++ b/config/postmark.php
@@ -27,4 +27,23 @@ return [
         'timeout' => 10,
         'connect_timeout' => 10,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validate TLS Upgrade
+    |--------------------------------------------------------------------------
+    |
+    | On February 16, 2021 Postmark announced some upcoming TLS
+    | configuration changes for API users. Use this field to
+    | change the hostname to their temporary endpoint.
+    | This option will cease to work after the
+    | April 13th cut off date.
+    |
+    | https://postmarkapp.com/updates/upcoming-tls-configuration-changes-for-api-users-action-may-be-required
+    |
+    */
+
+    'validating' => [
+        'tls' => env('POSTMARK_VALIDATING_TLS', false),
+    ],
 ];

--- a/config/postmark.php
+++ b/config/postmark.php
@@ -24,26 +24,8 @@ return [
     */
 
     'guzzle' => [
+        'base_uri' => env('POSTMARK_BASE_URI', 'https://api.postmarkapp.com'),
         'timeout' => 10,
         'connect_timeout' => 10,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Validate TLS Upgrade
-    |--------------------------------------------------------------------------
-    |
-    | On February 16, 2021 Postmark announced some upcoming TLS
-    | configuration changes for API users. Use this field to
-    | change the hostname to their temporary endpoint.
-    | This option will cease to work after the
-    | April 13th cut off date.
-    |
-    | https://postmarkapp.com/updates/upcoming-tls-configuration-changes-for-api-users-action-may-be-required
-    |
-    */
-
-    'validating' => [
-        'tls' => env('POSTMARK_VALIDATING_TLS', false),
     ],
 ];

--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Coconuts\Mail;
 
-use DateTime;
+use function array_merge;
 use function config;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Support\ServiceProvider;
@@ -68,14 +68,10 @@ class PostmarkServiceProvider extends ServiceProvider
 
     protected function guzzle(array $config): HttpClient
     {
-        $now = new DateTime();
-        $expiresAt = new DateTime('2021-04-13T00:00:00');
-        $expired = $now > $expiresAt;
-
-        return new HttpClient($config + [
-            'base_uri' => config('postmark.validating.tls') && !$expired
-                ? 'https://api-ssl-temp.postmarkapp.com'
-                : 'https://api.postmarkapp.com',
-        ]);
+        return new HttpClient(array_merge($config, [
+            'base_uri' => empty($config['base_uri'])
+                ? 'https://api.postmarkapp.com'
+                : $config['base_uri']
+        ]));
     }
 }

--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Coconuts\Mail;
 
+use DateTime;
+use function config;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Support\ServiceProvider;
 
@@ -66,6 +68,14 @@ class PostmarkServiceProvider extends ServiceProvider
 
     protected function guzzle(array $config): HttpClient
     {
-        return new HttpClient($config);
+        $now = new DateTime();
+        $expiresAt = new DateTime('2021-04-13T00:00:00');
+        $expired = $now > $expiresAt;
+
+        return new HttpClient($config + [
+            'base_uri' => config('postmark.validating.tls') && !$expired
+                ? 'https://api-ssl-temp.postmarkapp.com'
+                : 'https://api.postmarkapp.com',
+        ]);
     }
 }

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -16,8 +16,6 @@ use Swift_MimePart;
 
 class PostmarkTransport extends Transport
 {
-    const API_ENDPOINT = 'https://api.postmarkapp.com/email';
-
     /** @var \GuzzleHttp\ClientInterface */
     protected $client;
 
@@ -42,10 +40,10 @@ class PostmarkTransport extends Transport
     public function getApiEndpoint(Swift_Mime_SimpleMessage $message): string
     {
         if ($this->templated($message)) {
-            return self::API_ENDPOINT.'/withTemplate';
+            return '/email/withTemplate';
         }
 
-        return self::API_ENDPOINT;
+        return '/email';
     }
 
     /**

--- a/tests/PostmarkServiceProviderTest.php
+++ b/tests/PostmarkServiceProviderTest.php
@@ -45,13 +45,13 @@ class PostmarkServiceProviderTest extends TestCase
     }
 
     /** @test */
-    public function will_register_http_client_with_temporary_base_url_depending_on_environment_setup()
+    public function will_allow_base_uri_to_be_overridden_from_config_value()
     {
         if (! $this->app->has('swift.transport')) {
             $this->markTestSkipped('swift.transport is only available for Laravel 6.0 and lower.');
         }
 
-        $this->app['config']->set('postmark.validating.tls', true);
+        $this->app['config']->set('postmark.guzzle.base_uri', 'https://api-ssl-temp.postmarkapp.com');
 
         tap(new PostmarkServiceProvider($this->app), function ($provider) {
             $provider->boot();

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -4,12 +4,12 @@ namespace Coconuts\Mail\Tests;
 
 use Coconuts\Mail\Exceptions\PostmarkException;
 use Coconuts\Mail\PostmarkTransport;
+use function json_encode;
+use function tap;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
-use function json_encode;
 use Swift_Attachment;
 use Swift_Message;
-use function tap;
 
 class PostmarkTransportTest extends TestCase
 {
@@ -55,7 +55,7 @@ class PostmarkTransportTest extends TestCase
     {
         $endpoint = $this->invokeMethod($this->transport, 'getApiEndpoint', [$this->message]);
 
-        $this->assertSame('https://api.postmarkapp.com/email', $endpoint);
+        $this->assertSame('/email', $endpoint);
     }
 
     /** @test */


### PR DESCRIPTION
## Description

Postmark is making some breaking, but necessary changes to their infrastructure that require consumers to test out their infrastructure. 

> To ensure the continued security of our systems, we wanted to let you know about some upcoming changes to our TLS (Transport Layer Security) configurations for API access. These changes may affect your application’s ability to continue to send mail through Postmark, so please read through this post in detail. These changes do not affect sending via SMTP.

This PR aims to introduce the ability to ~toggle a configuration value~ override the base_uri which will allow end-users to test out their infrastructure against Postmark's temporary endpoint.

## Motivation and context

This is necessary for ensuring upcoming changes on Postmarks end are supported on any projects given infrastructure. Fixes #122 

https://postmarkapp.com/updates/upcoming-tls-configuration-changes-for-api-users-action-may-be-required

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.