### PR TITLE
Throw Swift_TransportException for GuzzleConnect and GuzzleServer exc…

### DIFF
--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -57,7 +57,7 @@ class PostmarkTransport extends Transport
      * @return int
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws Swift_TransportException
+     * @throws \Swift_TransportException
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -6,6 +6,8 @@ use Coconuts\Mail\Exceptions\PostmarkException;
 use function collect;
 use function json_decode;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ServerException;
 use Illuminate\Mail\Transport\Transport;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -13,6 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 use Swift_Mime_Attachment;
 use Swift_Mime_SimpleMessage;
 use Swift_MimePart;
+use Swift_TransportException;
 
 class PostmarkTransport extends Transport
 {
@@ -54,16 +57,21 @@ class PostmarkTransport extends Transport
      * @return int
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws Swift_TransportException
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {
         $this->beforeSendPerformed($message);
 
-        $response = $this->client->request(
-            'POST',
-            $this->getApiEndpoint($message),
-            $this->payload($message)
-        );
+        try {
+            $response = $this->client->request(
+                'POST',
+                $this->getApiEndpoint($message),
+                $this->payload($message)
+            );
+        } catch (ConnectException | ServerException $exception) {
+            throw new Swift_TransportException($exception->getMessage(), $exception->getCode(), $exception);
+        }
 
         $messageId = $this->getMessageId($response);
 


### PR DESCRIPTION
The current implementation of the package throws a GuzzleConnect or GuzzleServer error in case Postmark can't handle the given request. In order for the (relatively new) Laravel failover mail driver to work, we should throw a Swift_TransportException instead. (Please see the send() function of the Swift_Transport_FailoverTransport class)

<!--- Provide a general summary of your changes in the Title above -->

## Description

Please see the general summary. 

## Motivation and context

This PR will make sure that the (relatively new) failover mail driver will work properly. 

## How has this been tested?

I tested the changes, I made to this package, in a working Laravel 8.58.0 application. 
I've (temp) changed the value of POSTMARK_BASE_URI to a faulty domain. Thus I received a GuzzleConnect exception. 
The change I made took care of throwing a Swift_TransportException based on that GuzzleConnect exception.

## Screenshots (if appropriate)

## Types of changes

I'm not really sure if this is a bug-fix or breaking change. I guess it's a breaking change as the send() function will now throw that Swift_TransportException instead of the GuzzleConnect & GuzzleServer Exceptions.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
