### PR TITLE
Adds PHP 8.1 to testing matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,10 +36,6 @@ jobs:
           - php: 8.1
             laravel: ^5.5
           - php: 8.1
-            laravel: ^6.0
-          - php: 8.1
-            laravel: ^7.0
-          - php: 8.1
             stability: prefer-lowest
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
           - php: 8.1
             laravel: ^5.5
           - php: 8.1
+            laravel: ^6.0
+          - php: 8.1
+            laravel: ^7.0
+          - php: 8.1
             stability: prefer-lowest
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
             laravel: ^6.0
           - php: 8.1
             laravel: ^7.0
+          - php: 8.1
+            stability: prefer-lowest
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.0, 7.4, 7.3, 7.2, 7.1 ]
+        php: [ 8.1, 8.0, 7.4, 7.3, 7.2, 7.1 ]
         laravel: [ ^8.0, ^7.0, ^6.0, ^5.5 ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
@@ -33,6 +33,12 @@ jobs:
             laravel: ^8.0
           - php: 8.0
             laravel: ^5.5
+          - php: 8.1
+            laravel: ^5.5
+          - php: 8.1
+            laravel: ^6.0
+          - php: 8.1
+            laravel: ^7.0
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 


### PR DESCRIPTION
## Description

This PR aims to add proven/tested support for PHP 8.1 for Laravel 8 (with the appropriate stable dependencies)

## Motivation and context

PHP 8.1 has been released and this library will need to prove support for it.

## How has this been tested?

Running automated tests against the appropriate dependency versions.