### PR TITLE
Adds dynamic server usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ In this case, the following object will be sent to Postmark as metadata.
 }
 ```
 
+## Postmark Servers
+
+Out of the box, we determine the Postmark server you send to using a configuration variable set within the environment you have deployed to. This works for most use cases, but if you have the need or desire to determine the Postmark server at runtime, you can supply a header during the sending process.
+
+```php
+use CraigPaul\Mail\PostmarkServerTokenHeader;
+use Symfony\Component\Mime\Email;
+
+public function build()
+{
+    $this->withSymfonyMessage(function (Email $message) {
+        $message->getHeaders()->add(new PostmarkServerTokenHeader('POSTMARK_TOKEN'))
+    });
+}
+```
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/src/PostmarkServerTokenHeader.php
+++ b/src/PostmarkServerTokenHeader.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CraigPaul\Mail;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+class PostmarkServerTokenHeader extends UnstructuredHeader
+{
+    public const NAME = 'X-Postmark-Server-Token';
+
+    public function __construct(string $value)
+    {
+        parent::__construct(self::NAME, $value);
+    }
+}

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -3,6 +3,8 @@
 namespace CraigPaul\Mail\Tests;
 
 use function basename;
+
+use CraigPaul\Mail\PostmarkServerTokenHeader;
 use CraigPaul\Mail\PostmarkTransport;
 use CraigPaul\Mail\PostmarkTransportException;
 use CraigPaul\Mail\TemplatedMailable;
@@ -168,6 +170,7 @@ class PostmarkTransportTest extends TestCase
 
         $message->getHeaders()->add(new TagHeader($email->getTag()));
         $message->getHeaders()->add(new MetadataHeader($metadata->getKey(), $metadata->getValue()));
+        $message->getHeaders()->add(new PostmarkServerTokenHeader($metadata->getValue()));
         $message->getHeaders()->addTextHeader($header->getKey(), $header->getValue());
 
         $symfonyMessage = $message->getSymfonyMessage();
@@ -182,7 +185,8 @@ class PostmarkTransportTest extends TestCase
             $header = $email->getHeader();
             $metadata = $email->getMetadata();
 
-            return $request['MessageStream'] === $this->getMessageStreamId()
+            return $request->hasHeader('X-Postmark-Server-Token', $metadata->getValue())
+                && $request['MessageStream'] === $this->getMessageStreamId()
                 && $request['Tag'] === $email->getTag()
                 && $request['Metadata'] === [$metadata->getKey() => $metadata->getValue()]
                 && $request['Headers'] === [['Name' => $header->getKey(), 'Value' => $header->getValue()]];

--- a/tests/PostmarkTransportTest.php
+++ b/tests/PostmarkTransportTest.php
@@ -3,7 +3,6 @@
 namespace CraigPaul\Mail\Tests;
 
 use function basename;
-
 use CraigPaul\Mail\PostmarkServerTokenHeader;
 use CraigPaul\Mail\PostmarkTransport;
 use CraigPaul\Mail\PostmarkTransportException;


### PR DESCRIPTION
## Description

This allows end-users to dynamically determine which Postmark server they want to use at runtime instead of being limited to one server for the entire deployment environment, should they want to.

## Motivation and context

Fixes #95 

## How has this been tested?

Through the use of automated tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
