### PR TITLE
Fixes typed property error

### DIFF
--- a/src/TemplatedMailMessage.php
+++ b/src/TemplatedMailMessage.php
@@ -6,11 +6,11 @@ use Illuminate\Notifications\Messages\MailMessage as Message;
 
 class TemplatedMailMessage extends Message
 {
-    protected string $alias;
+    protected ?string $alias = null;
 
-    protected array $data;
+    protected array $data = [];
 
-    protected int $id;
+    protected ?int $id = null;
 
     public $view = 'postmark::template';
 

--- a/tests/Notifications/TemplatedNotification.php
+++ b/tests/Notifications/TemplatedNotification.php
@@ -10,7 +10,8 @@ use Illuminate\Notifications\Notification;
 class TemplatedNotification extends Notification
 {
     public function __construct(
-        protected Template $template
+        protected Template $template,
+        protected string $uses,
     ) {
     }
 
@@ -21,9 +22,14 @@ class TemplatedNotification extends Notification
 
     public function toMail(): MailMessage
     {
-        return (new TemplatedMailMessage())
-            ->alias($this->template->getAlias())
-            ->identifier($this->template->getId())
-            ->include($this->template->getModel());
+        $message = (new TemplatedMailMessage());
+
+        if ($this->uses === 'alias') {
+            $message = $message->alias($this->template->getAlias());
+        } else {
+            $message = $message->identifier($this->template->getId());
+        }
+
+        return $message->include($this->template->getModel());
     }
 }


### PR DESCRIPTION
## Description

Existing tests for templated messages were not matching real-world expectations of supplying either an alias or identifier but were rather sending both at once. This was hiding a type error that was discovered in #135.

## Motivation and context

Fixes #135 

## How has this been tested?

Automated tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
