### PR TITLE
Fix unchecked array-key in PostmarkServiceProvider.php.

### DIFF
--- a/src/PostmarkServiceProvider.php
+++ b/src/PostmarkServiceProvider.php
@@ -16,12 +16,12 @@ class PostmarkServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'postmark');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'postmark');
 
         $this->app['mail.manager']->extend('postmark', function ($config) {
             return new PostmarkTransport(
                 $this->app->make(Factory::class),
-                $config['message_stream_id'],
+                $this->app->make('config')->get('services.postmark.message_stream_id'),
                 $this->app->make('config')->get('services.postmark.token'),
             );
         });


### PR DESCRIPTION
Fix an unchecked array-key in PostmarkServiceProvider.php.

## Description

Since last 2 commits there was an unchecked array-key for `message_stream_id` in ServiceProvider.

## Motivation and context

Closes #141

## How has this been tested?

Tested with default laravel mail-config and mailable-setup from a system running good before last update.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [ ] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

