### PR TITLE
Resolve PHP deprecation for json_decode

### DIFF
--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -12,14 +12,12 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\MessageConverter;
 use Symfony\Component\Mime\RawMessage;
-
 use function array_filter;
 use function array_map;
 use function array_merge;
 use function implode;
 use function in_array;
 use function json_decode;
-
 use const JSON_OBJECT_AS_ARRAY;
 
 class PostmarkTransport implements TransportInterface
@@ -184,7 +182,7 @@ class PostmarkTransport implements TransportInterface
 
     protected function getTemplatedContent(Email $email): ?array
     {
-        return json_decode($email->getHtmlBody(), flags: JSON_OBJECT_AS_ARRAY);
+        return json_decode($email->getHtmlBody() ?? null, flags: JSON_OBJECT_AS_ARRAY);
     }
 
     protected function stringifyAddresses(array $addresses): string

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -184,7 +184,7 @@ class PostmarkTransport implements TransportInterface
 
     protected function getTemplatedContent(Email $email): ?array
     {
-        return json_decode($email->getHtmlBody() ?? null, flags: JSON_OBJECT_AS_ARRAY);
+        return json_decode($email->getHtmlBody() ?? '', flags: JSON_OBJECT_AS_ARRAY);
     }
 
     protected function stringifyAddresses(array $addresses): string

--- a/src/PostmarkTransport.php
+++ b/src/PostmarkTransport.php
@@ -12,12 +12,14 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\MessageConverter;
 use Symfony\Component\Mime\RawMessage;
+
 use function array_filter;
 use function array_map;
 use function array_merge;
 use function implode;
 use function in_array;
 use function json_decode;
+
 use const JSON_OBJECT_AS_ARRAY;
 
 class PostmarkTransport implements TransportInterface


### PR DESCRIPTION
## Description

This will resolve a PHP deprecation for `json_decode()` when `Symfony\Component\Mime\Email::$html` is `null`. This happen when using `Illuminate\Support\Facades\Mail::raw()` where `$html` is never set on the Email class.

## Motivation and context

We're in the process of eliminating PHP deprecations in our codebase for safe PHP upgrades in the future.

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ ] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [ ] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
