### PR TITLE
Document Postmark MessageID capture and listener setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,52 @@ In this case, the following object will be sent to Postmark as metadata.
 }
 ```
 
+## Capture Postmark MessageID
+
+The Postmark API returns a message ID which can be used to query message delivery status 
+
+To capture this data setup an event listener 
+
+app/Listeners/MessageSentListener.php
+```php
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Mail\Events\MessageSent;
+
+class HandleMessageSent
+{
+    public function handle(MessageSent $message)
+    {
+        $messageId = $event->sent->getSymfonySentMessage()->getMessageId();
+
+        // ...
+    }
+}
+```
+
+Either  shouldDiscoverEvents should return true or the event listener must be registered
+
+app/Providers/EventServiceProvider.php 
+```php
+<?php
+
+namespace App\Providers;
+
+use App\Listeners\HandleMessageSent;
+use Illuminate\Mail\Events\MessageSent;
+
+class EventServiceProvider extends ServiceProvider
+{
+    protected $listen = [
+        MessageSent::class => [
+            HandleMessageSent::class,
+        ],
+    ];
+}
+```
+
 ## Postmark Servers
 
 Out of the box, we determine the Postmark server you send to using a configuration variable set within the environment you have deployed to. This works for most use cases, but if you have the need or desire to determine the Postmark server at runtime, you can supply a header during the sending process.


### PR DESCRIPTION
Added instructions for capturing Postmark MessageID and configuring event listeners.

Based on 

https://github.com/craigpaul/laravel-postmark/issues/146

https://github.com/craigpaul/laravel-postmark/issues/43

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added some docs to README that were in issues

## Motivation and context

I want to use the postmark API to determine delivery status of emails - so I want to store the message ID for use in later API calls

I see other people have needed this to 

Adding it to the docs instead of in (closed) issues

## How has this been tested?

I have followed the instructions and run the code

I haven't added unit tests - this is just a documentation change

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of these - just adding docs

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- x[ ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ x] My pull request addresses exactly one patch/feature.
- [ x] I have created a branch for this patch/feature.
- [ x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ]x If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

No tests added - not a code change