### PR TITLE
chore: add guzzle v8 support and drop support for Laravel 10.x and 11.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,36 +11,26 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.5, 8.4, 8.3, 8.2, 8.1]
-        laravel: [^10.0, ^11.0, ^12.0, ^13.0]
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: [^12.0, ^13.0]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: ^10.0
-            testbench: ^8.0
-          - laravel: ^11.0
-            testbench: ^9.2
           - laravel: ^12.0
             testbench: ^10.0
           - laravel: ^13.0
             testbench: ^11.0
         exclude:
-          - laravel: ^11.0
-            php: 8.1
-          - laravel: ^12.0
-            php: 8.1
           - laravel: ^13.0
             php: 8.2
-          - laravel: ^13.0
-            php: 8.1
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-laravel-${{ matrix.laravel }}-composer-${{ hashFiles('composer.lock') }}

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,17 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.9|^8.0",
-        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/mail": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
+        "illuminate/http": "^12.0|^13.0",
+        "illuminate/mail": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
         "ext-gd": "*",
         "fakerphp/faker": "^1.17",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-        "phpunit/phpunit": "^10.0|^11.5.3|^12.5.12"
+        "orchestra/testbench": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.5.3|^12.5.12|^13.0"
     },
     "suggest": {
         "mvdnbrk/postmark-inbound": "Allows you to process Postmark Inbound Webhooks."

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^7.9|^8.0",
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/mail": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR replaces the direct dependency on Guzzle by a dependency on `illuminate/http`. This package doesn't use any classes or constants of Guzzle directly. It is using the HTTP-client of Laravel itself which has support for Guzzle v8 (https://github.com/illuminate/http/blob/13.x/composer.json). This change makes dependency mangement for this package easier in the end as there is no need to take future Guzzle-releases into account (that's the responsibility of the Laravel framework now).

An alternative would be:

```diff
-        "guzzlehttp/guzzle": "^7.9",
+        "guzzlehttp/guzzle": "^7.9|^8.0",
```

## Motivation and context

The goal of my PR is to add support for Guzzle v8 to this package, as Guzzle v8 is supported since Laravel v13.26. This package is one of the blockers for that upgrade.


## How has this been tested?
Tested on my own dev environment and this PR will probably trigger some automated tests too.

## Screenshots (if appropriate)
n/a

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
